### PR TITLE
1 fix duplicate serverlocationdata bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ COMING SOON: [React Marketing Tools Demo](https://)
 
     const analyticsConfig = { 
         appName: 'my-awesome-app', // required
+        appSessionCookieName: 'APP_SESSION',
         eventActionPrefix: { // this will extend the default values of eventActionPrefix 
             ACTION: 'ACTION',
             OTHER_EVENT_NAME_TYPE: 'OTHER_EVENT_NAME_TYPE'
@@ -60,6 +61,17 @@ COMING SOON: [React Marketing Tools Demo](https://)
         withServerLocationInfo: false, // (optional) has default value
     }
 
+    /**
+        * @type {Object} buildConfig -> options: all attributes of the options object must have a value, other than withDeviceInfo.
+        * @property {string} appName: the name of your app this value must be passed in.
+        * @property {string} appSessionCookieName This is used to get the cookie from storage based on a key you use, the value from the cookie will be used in "client_id:"
+        * @property {Object} eventActionPrefix: is a { key: 'value' } object that allows you to extend "analyticsEventActionPrefixList" object with custom eventActionPrefix. To see the build in list call the function showMeBuildInEventActionPrefixList().
+        * @property {Array} globalEventActionList: is a { key: 'value' } object that allows you to extend "analyticsGlobalEventActionList" object with custom eventActionNames. To see the build in list call the function showMeBuildInGlobalEventActionList().
+        * @property {Array} includeUserKeys: is an array of strings that represent keys from your user data that you want to whitelist, user data you wan to hash.
+        * @property {Object} TOKENS: is a { key: 'value' } object that includes the following keys, IP_INFO_TOKEN, GA4_PUBLIC_API_SECRET, GA4_PUBLIC_MEASUREMENT_ID, depending on if you need these features enabled.
+        * @property {Boolean} withDeviceInfo: if you want device information added to "globalVars" set this to true false by default.
+        * @property {Boolean} withServerLocationInfo: if you want server information added to "journeyProps" set this to true false by default.
+    */
     buildConfig(analyticsConfig)
 
     ReactDOM.createRoot(document.getElementById('root')).render(
@@ -80,6 +92,7 @@ COMING SOON: [React Marketing Tools Demo](https://)
     function App() {
         const [count, setCount] = useState(0)
         const {
+            appSessionCookieName,
             analyticsPlatform,
             eventActionPrefixList,
             analyticsGlobalEventActionList
@@ -96,6 +109,9 @@ COMING SOON: [React Marketing Tools Demo](https://)
         } = useMarketingApi(ContextApi)
 
         useEffect(function appLoadPageLandingWelcome() {
+            // create session cookie, useful for unauthenticated user tracking and other things
+            document.cookie = `${appSessionCookieName}=${uuid()};max-age=${70};SameSite=Strict;Secure`
+
             const eventNameInfo = {
                 actionPrefix: eventActionPrefixList.JOURNEY,
                 description: 'Welcome Landing',

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,7 +24,7 @@ __Changed__
 
 ## [0.0.4] - 20-08-2022
 __Fixed__ 
-- serverLocationData bug
+- serverLocationData bug duplicate entries in payload
 __Changed__
 - README
 __Added__

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - __Fixed__ for any bug fixes.
 - __Security__ in case of vulnerabilities.
 
-## [0.0.0] - 19-08-2022
+## [0.0.1] - 13-08-2022
 __Added__
 - README
 - CHANGELOG
@@ -21,3 +21,11 @@ __Added__
 ## [0.0.1] - 19-08-2022
 __Changed__
 - README
+
+## [0.0.4] - 20-08-2022
+__Fixed__ 
+- serverLocationData bug
+__Changed__
+- README
+__Added__
+- appSessionCookieName and appName to useMarketingState Context 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-marketing-tools",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "",
   "license": "MIT",
   "author": "bronz3beard <exempli.gratia.webdesign@gmail.com> (https://www.eg-web-design.com/)",

--- a/src/lib/analytics/analyticsEventService.js
+++ b/src/lib/analytics/analyticsEventService.js
@@ -5,7 +5,6 @@ import {
 } from './helpers'
 import ga4GoogleAnalyticsEventTracking from './ga4GoogleAnalyticsEventTracking'
 import handleDataLayerPush from './handleDataLayerPush'
-import { buildServerLocationData } from '../ipInfo'
 import { analyticsPlatform, config } from '../buildConfig'
 import {
   objectHasAttributes,
@@ -36,12 +35,7 @@ const trackAnalyticsEvent = async options => {
     dataLayerCheck = false,
     consoleLogData = null,
   } = options
-
-  const { includeUserKeys, withServerLocationInfo } = config
-
-  const serverLocationData = await buildServerLocationData(
-    withServerLocationInfo,
-  )
+  const { includeUserKeys } = config
 
   assertIsTrue(
     objectHasAttributes(analyticsPlatform, analyticsType),
@@ -68,9 +62,6 @@ const trackAnalyticsEvent = async options => {
       globalAppEvent: eventNameInfo.globalAppEvent,
       data: {
         ...data,
-        ...(!serverLocationData
-          ? []
-          : { serverLocationData: serverLocationData }),
       },
       userDetails: buildNewUserData(data, includeUserKeys),
       consoleLogData,

--- a/src/lib/analytics/helpers.js
+++ b/src/lib/analytics/helpers.js
@@ -3,6 +3,7 @@ import {
   objectHasAttributes,
   replaceWhiteSpace,
 } from '../utilities/commonFunctions'
+import { buildServerLocationData } from '../ipInfo'
 import DeviceDetector from 'device-detector-js'
 import { config } from '../buildConfig'
 import { assertIsTrue } from '../utilities/assertValueCheckers'
@@ -114,12 +115,17 @@ export const buildAnalyticsEventName = eventNameInfo => {
 export const buildEventDataObject = async (data, globalAppEvent) => {
   const timeElapsed = Date.now()
   const today = new Date(timeElapsed)
+  const { withServerLocationInfo } = config
+
+  const serverLocationData = await buildServerLocationData(
+    withServerLocationInfo,
+  )
 
   // this is data that is always sent in the payload
   let actionDataObject = {
     // TODO:: add default variable from user into this object maybe?
     HIT_TIMESTAMP: today.toISOString(),
-    ...(!data.serverLocationData ? [] : data.serverLocationData),
+    ...(!serverLocationData ? [] : serverLocationData),
   }
 
   return await _appendValuesToJourneyData(

--- a/src/lib/index.jsx
+++ b/src/lib/index.jsx
@@ -20,6 +20,8 @@ export const ContextApi = createContext({})
 
 const ProviderState = ContextState.Provider
 ProviderState.propTypes = {
+  appName: string,
+  appSessionCookieName: string,
   analyticsPlatform: shape({
     GOOGLE: string,
     FACEBOOK: string,
@@ -51,6 +53,8 @@ export const ReactMarketingProvider = ({ children }) => {
   const stateValue = useMemo(
     () => ({
       analyticsPlatform,
+      appName: config.appName,
+      appSessionCookieName: config.appSessionCookieName,
       eventActionPrefixList: config.eventActionPrefixList,
       analyticsGlobalEventActionList: config.analyticsGlobalEventActionList,
     }),

--- a/src/lib/ipInfo/index.js
+++ b/src/lib/ipInfo/index.js
@@ -10,19 +10,19 @@ export const buildServerLocationData = async withServerLocationInfo => {
   )
 
   if (withServerLocationInfo && TOKENS?.IP_INFO_TOKEN) {
-    const ipInfo = await getIpInfo(TOKENS.IP_INFO_TOKEN).then(
+    const ipInfo = await getIpInfo(TOKENS?.IP_INFO_TOKEN).then(
       response => response,
     )
 
     const serverLocationData = {
-      city: ipInfo.city,
-      country: ipInfo.country,
-      hostname: ipInfo.hostname,
-      ip: ipInfo.ip,
-      loc: ipInfo.loc,
-      postal: ipInfo.postal,
-      region: ipInfo.region,
-      timezone: ipInfo.timezone,
+      CITY: ipInfo.city,
+      COUNTRY: ipInfo.country,
+      HOSTNAME: ipInfo.hostname,
+      IP: ipInfo.ip,
+      LOC: ipInfo.loc,
+      POSTAL: ipInfo.postal,
+      REGION: ipInfo.region,
+      TIMEZONE: ipInfo.timezone,
     }
 
     return serverLocationData


### PR DESCRIPTION
Summary of the new changes, feature.
Include a little context. 

- When `withServerLocationInfo` and using a token to get server data all server data was inside `journeyProps` twice, this fix should remove that issue.

Please list if any, dependencies that are required for this change.

## [0.0.4] - 20-08-2022
### Added
- `appSessionCookieName` and `appName` to `useMarketingState` Context 

### Fixed
Please delete options that are not relevant.
- [x] Bug fix duplicate `serverLocationData` in `journeyProps` payload (non-breaking change which fixes an issue) 

## Final check before release
- [x] update [CHANGELOG.md](https://github.com/bronz3beard/react-merketing-tools/blob/main/docs/CHANGELOG.md)